### PR TITLE
Extract data reformat logic into a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ inclusive pull requests to foster a healthier open source community.
     2. [Build Dataset](#build-dataset)
         - [Extract Raw Data from GitHub](#extract-raw-data-from-github)
         - [Annotate](#annotate)
+        - [Feature Vector Creation](#feature-vector-creation)
     3. [Train models](#train-models)
 4. [Documentation](#documentation)
 5. [Blog Posts](#blog-posts)
@@ -102,19 +103,31 @@ python ./ml-conversational-analytic-tool/runDataExtraction.py <organization> <re
 
 #### Annotate
 
-`featureVector.py` prepares your data for annotation use. Run the script by passing in path to `rawdatafile` and `words`.
+`github_data.py` prepares your data for annotation use. Run the script by passing in path to `rawdatafile`.
 
 ```python
-python ./ml-conversational-analytic-tool/featureVector.py <rawdatafile> <words> -unannotated
+python ./ml-conversational-analytic-tool/github_data.py <rawdatafile> --name <output_filename>
 ```
 
 - `rawdatafile` is location of raw data csv
-- `words` is location of file with lookup words (not needed for annotation purposes)
-- (optional) `-unannotated` is an optional flag to generate data for annotation
+- `name` (optional) is the output filename.
 
-To annotate the raw data extracted we recommend using
-[Data Annotator For Machine Learning](https://github.com/vmware/data-annotator-for-machine-learning). The quality of
-the data and the model very much depends on annotation best practices.
+
+The quality of the data and the model very much depends on annotation best practices.
+    To annotate the raw data extracted we recommend using
+    [Data Annotator For Machine Learning](https://github.com/vmware/data-annotator-for-machine-learning). 
+
+
+#### Feature Vector Creation 
+`featureVector.py` creates feature vector based on the `rawdatafile` and optionally `words` file. Default features 
+include sentiment and code blocks. `Words` file contains words important in measuring inclusiveness and 
+constructiveness. This functionality could be used instead of manual annotation.
+
+```python
+python ./ml-conversational-analytic-tool/featureVector.py <rawdatafile> --words <words_filename> --name <output_filename>
+```
+- `words` (optional) path to the words file
+- `name`  (optional) name of the output file.
 
 ### Train models
 

--- a/ml-conversational-analytic-tool/commentAnalysis.py
+++ b/ml-conversational-analytic-tool/commentAnalysis.py
@@ -4,9 +4,9 @@
 import argparse
 
 import nltk
+from nltk.sentiment import vader
 
 nltk.download('vader_lexicon')  # Model download
-from nltk.sentiment.vader import SentimentIntensityAnalyzer
 
 
 class CommentAnalyzer:
@@ -16,7 +16,7 @@ class CommentAnalyzer:
         Parameters: words - list of words to count
         """
         self.word_count = {word.lower(): 0 for word in words}  # Create dictionary with list items as key
-        self.vader_sentiment = SentimentIntensityAnalyzer()  # Initialize sentiment analysis model
+        self.vader_sentiment = vader.SentimentIntensityAnalyzer()  # Initialize sentiment analysis model
 
     def analyzeComment(self, comment):
         """
@@ -38,6 +38,8 @@ class CommentAnalyzer:
         Parameters: text - string.
         Returns: string after cleaning
         """
+        if not isinstance(text, str):
+            return ""
         cleaned_text = text.strip()  # Remove trailing and starting spaces
         cleaned_text = cleaned_text.lower()  # Convert to lowercase
         return cleaned_text
@@ -84,12 +86,13 @@ class CommentAnalyzer:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Analyze input text segment.')
     parser.add_argument('text', help='Text to analyze')
-    parser.add_argument('words', help='File containing words to count')
+    parser.add_argument('-w', '--words', required=False, help='File containing words to count')
 
     args = parser.parse_args()
     # Form word list through the file
     word_list = []
-    with open(args.words, 'r') as word_file:
-        word_list = word_file.read().replace(" ", "").strip().split(",")
+    if args.words:
+        with open(args.words, 'r') as word_file:
+            word_list = word_file.read().replace(" ", "").strip().split(",")
     analyzer = CommentAnalyzer(word_list)
     print(analyzer.analyzeComment(args.text))

--- a/ml-conversational-analytic-tool/featureVector.py
+++ b/ml-conversational-analytic-tool/featureVector.py
@@ -1,13 +1,15 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 import argparse
-import ast
 import os
+from pathlib import Path
 
 import pandas as pd
 
+import utils
 from commentAnalysis import CommentAnalyzer
+
+FILE_NAME_SUFFIX = "_annotated"
 
 
 class Featurizer:
@@ -31,17 +33,10 @@ class Featurizer:
         self.raw_filename = filename
         self.raw_data = pd.read_csv(filename)
 
-        # Temporary method to convert json strings to dictionary
-        def stringToDict(string):
-            string = ast.literal_eval(string)
-            for i in range(len(string)):
-                string[i] = ast.literal_eval(string[i])
-            return string
-
         # Convert Comments and Review Comments to dictionary
-        self.raw_data['Comments'] = self.raw_data['Comments'].apply(lambda comment: stringToDict(comment))
-        self.raw_data['Review_Comments'] = self.raw_data['Review_Comments'].apply(lambda comment: stringToDict(comment))
-        print("Done reading raw data.")
+        self.raw_data['Comments'] = self.raw_data['Comments'].apply(lambda comment: utils.string_to_dict(comment))
+        self.raw_data['Review_Comments'] = self.raw_data['Review_Comments'].apply(
+            lambda comment: utils.string_to_dict(comment))
 
     def setupCommentAnalyzer(self, filename):
         """
@@ -51,13 +46,14 @@ class Featurizer:
         word_list = []
 
         # Open file to obtain list of words in Comment Analzyer
-        with open(filename, 'r') as wordFile:
-            word_list = wordFile.read().replace(" ", "").strip().split(',')
+        if filename:
+            with open(filename, 'r') as wordFile:
+                word_list = wordFile.read().replace(" ", "").strip().split(',')
         self.commentAnalyzer = CommentAnalyzer(word_list)
         self.analysis_features = self.analysis_features + word_list
         print("Comment Analyzer Setup")
 
-    def formFeatures(self, export_filename="", export=True):
+    def formFeatures(self):
         """
         Function to create/export dataset with desired features
         Inputs: Name of file to export (string), export flag (boolean)
@@ -143,78 +139,26 @@ class Featurizer:
             # Add pull features to list of row features
             features.append(row_features)
         export_df = pd.DataFrame(data=features)
-
-        if export:
-            if not os.path.exists('exports'):
-                os.mkdir('exports')
-            if export_filename == "":
-                export_df.to_csv("exports/" + self.raw_filename + "_analysis.csv", index=False)
-            else:
-                export_df.to_csv("exports/" + export_filename, index=False)
-
-        return export_df
-
-    def pullStringConversation(self, export_filename="", export=True):
-        """
-        Function to form conversation string given communication on a pull request
-        Inputs: Name of file to export (string), export flag (boolean)
-        """
-
-        # Store each interaction and pull URL for export
-        string_conversations = []
-        pull_urls = []
-        pull_numbers = []
-
-        for index, row in self.raw_data.iterrows():
-            # Make pull message
-            conversation = "{} ({}) : {}\n{}".format(row["User"], row["Created_At"], row["Title"], row["Body"])
-            temp_df_comments = pd.DataFrame(row['Comments'])
-            temp_df_review_comments = pd.DataFrame(row["Review_Comments"])
-
-            if len(temp_df_comments) > 0 or len(temp_df_review_comments) > 0:
-                all_comments = temp_df_comments.append(temp_df_review_comments)
-                all_comments['Created_At'] = pd.to_datetime(all_comments['Created_At'])
-                all_comments = all_comments.sort_values(by=['Created_At'])  # Sort data so as to export in order
-
-                for comment_index, comment_row in all_comments.iterrows():
-                    conversation = conversation + "\n{} ({}) : {}".format(comment_row["User"],
-                                                                          comment_row["Created_At"],
-                                                                          comment_row["Body"])
-            string_conversations.append(conversation.encode("ascii", "ignore").decode())
-            pull_urls.append(row["URL"])
-            pull_numbers.append(row["Number"])
-
-        # Export converation field dataset
-        export_df = pd.DataFrame()
-        export_df["Number"] = pull_numbers
-        export_df["URL"] = pull_urls
-        export_df["Thread"] = string_conversations
-
-        if export:
-            if not os.path.exists('exports'):
-                os.mkdir('exports')
-            if export_filename == "":
-                export_df.to_csv("exports/" + self.raw_filename + "_analysis.csv", index=False)
-            else:
-                export_df.to_csv("exports/" + export_filename, index=False)
         return export_df
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Form features from raw data.')
     parser.add_argument('rawdatafile', help='Raw Data Filename')
-    parser.add_argument('words', help='File containing words to count')
-    parser.add_argument('-unannotated', action='store_true', default=False, help='Create file for annotation')
+    parser.add_argument('-w', '--words', required=False, help='File containing words to count')
+    parser.add_argument('-n', '--name', required=False, help='Output file name. If not specified, the name is '
+                                                             'constructed like this: <rawdatafile>{'
+                                                             'suffix}.csv'.format(suffix=FILE_NAME_SUFFIX))
+
     args = parser.parse_args()
+
     RETAINED_FEATURES = ["Number", "URL", "Title", "State", "Body", "Deletions", "Additions", "User", "Comments_Num",
                          "Commits_Num", "Created_At", "Closed_At", "Merged", "Merged_At", "Review_Comments_Num"]
     COMMENT_ANALYSIS_FEATURES = ["Sentiment", "Code Blocks"]
+
     featurizer = Featurizer(RETAINED_FEATURES, COMMENT_ANALYSIS_FEATURES)
-
     featurizer.readRawData(args.rawdatafile)
-
-    if args.unannotated:
-        featurizer.pullStringConversation('unannotated.csv')
-    else:
-        featurizer.setupCommentAnalyzer(args.words)
-        featurizer.formFeatures()
+    featurizer.setupCommentAnalyzer(args.words)
+    df = featurizer.formFeatures()
+    file_name = utils.construct_file_name(args.name, args.rawdatafile, FILE_NAME_SUFFIX)
+    utils.export_to_cvs(df, file_name)

--- a/ml-conversational-analytic-tool/github_data.py
+++ b/ml-conversational-analytic-tool/github_data.py
@@ -1,0 +1,84 @@
+import argparse
+
+import pandas as pd
+
+import utils
+
+FILE_NAME_SUFFIX = "_unannotated"
+
+
+class GitHubData:
+    """
+    Reformat raw data for annotation
+    """
+
+    def __init__(self, raw_filename):
+        self.raw_filename = raw_filename
+        self.raw_data = None
+
+    def read_raw_data(self):
+        """
+        Function to read raw data stored as csv
+        """
+        self.raw_data = pd.read_csv(self.raw_filename)
+
+        # Convert Comments and Review Comments to dictionary
+        self.raw_data['Comments'] = self.raw_data['Comments'].apply(lambda comment: utils.string_to_dict(comment))
+        self.raw_data['Review_Comments'] = self.raw_data['Review_Comments'].apply(lambda comment: utils.string_to_dict(comment))
+
+    def reformat_data(self):
+        """
+        Function to reformat raw data as form conversation strings given communication on a pull requests
+        """
+
+        # Store each interaction and pull URL for export
+        conversations = []
+        pull_urls = []
+        pull_numbers = []
+
+        for index, row in self.raw_data.iterrows():
+            # Make pull message
+            conversations.append(self.merge_comments(row))
+            pull_urls.append(row["URL"])
+            pull_numbers.append(row["Number"])
+
+        # Export conversation field dataset
+        export_df = pd.DataFrame()
+        export_df["Number"] = pull_numbers
+        export_df["URL"] = pull_urls
+        export_df["Thread"] = conversations
+        return export_df
+
+    def merge_comments(self, row):
+        """
+        merge comments and review comments to form a conversation
+        """
+        conversation = "{} ({}) : {}\n{}".format(row["User"], row["Created_At"], row["Title"], row["Body"])
+        temp_df_comments = pd.DataFrame(row['Comments'])
+        temp_df_review_comments = pd.DataFrame(row["Review_Comments"])
+        if len(temp_df_comments) > 0 or len(temp_df_review_comments) > 0:
+            all_comments = temp_df_comments.append(temp_df_review_comments)
+            all_comments['Created_At'] = pd.to_datetime(all_comments['Created_At'])
+            all_comments = all_comments.sort_values(by=['Created_At'])  # Sort data so as to export in order
+
+            for comment_index, comment_row in all_comments.iterrows():
+                conversation = conversation + "\n{} ({}) : {}".format(comment_row["User"],
+                                                                      comment_row["Created_At"],
+                                                                      comment_row["Body"])
+        return conversation.encode("ascii", "ignore").decode()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Reformat raw data for annotation.')
+    parser.add_argument('rawdatafile', help='Raw Data Filename')
+    parser.add_argument('-n', '--name', required=False, help='Output file name. If not specified, the name is '
+                                                             'constructed like this: <rawdatafile>{'
+                                                             'suffix}.csv'.format(suffix=FILE_NAME_SUFFIX))
+    args = parser.parse_args()
+
+    data_reformat = GitHubData(args.rawdatafile)
+    data_reformat.read_raw_data()
+
+    df = data_reformat.reformat_data()
+    file_name = utils.construct_file_name(args.name, args.rawdatafile, FILE_NAME_SUFFIX)
+    utils.export_to_cvs(df, file_name)

--- a/ml-conversational-analytic-tool/utils.py
+++ b/ml-conversational-analytic-tool/utils.py
@@ -1,0 +1,39 @@
+import ast
+import os
+from pathlib import Path
+
+import pandas as pd
+
+EXPORTS_DIR = "exports"
+
+
+def export_to_cvs(export_df: pd.DataFrame, name):
+    """
+    Export DataFrame into csv file with name constructed based on the given name or default_name
+    """
+
+    if not os.path.exists(EXPORTS_DIR):
+        os.mkdir(EXPORTS_DIR)
+
+    file = os.path.join(EXPORTS_DIR, name)
+
+    export_df.to_csv(file, index=False)
+    print("Output file: ", os.path.abspath(file))
+
+
+def construct_file_name(name, raw_datafile, suffix):
+    if name:
+        _, file_extension = os.path.splitext(name)
+        if not file_extension:
+            name = name + ".csv"
+        return name
+    else:
+        return Path(raw_datafile).stem + suffix + ".csv"
+
+
+def string_to_dict(string):
+    """Function to convert json strings to dictionary"""
+    string = ast.literal_eval(string)
+    for i in range(len(string)):
+        string[i] = ast.literal_eval(string[i])
+    return string


### PR DESCRIPTION
Extract data reformat logic into a separate file - github_data.py

Available commands:
```
python ml-conversational-analytic-tool/featureVector.py  <raw_data_file> --words <words_file> --name <output_file_name>
python ml-conversational-analytic-tool/github_data.py  <raw_data_file> --name <output_file_name>
python ml-conversational-analytic-tool/commentAnalysis.py "Comment Message - Merry Christmas" --words <words_file>
```

`--name` is an optional parameter (supported by github_data.py and featureFector.py)
`--words` is an optional parameter (supported by featureVector.py and commentAnalysis.py)

Fixes: https://github.com/vmware-labs/ml-conversational-analytic-tool/issues/4

Signed-off-by: Diana Atanasova <dianaa@vmware.com>
