### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @annajung @difince @tzstoyanov @enyinna1234 @pramodrj07


### PR DESCRIPTION
The CODEOWNERS file enables automatic assignment of reviewers to any new PR created in a repository.
This file is pre-loaded with the active members of this project for now, but can be changed with time.

For more information, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners