### PR TITLE
Automatic docs build

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,0 +1,42 @@
+name: docs-build
+on :
+  push:
+    branches:
+      - main
+    paths:
+      - "mcat/*.py"
+
+jobs:
+  docs-build:
+    name: Automatic docs build
+    runs-on: ubuntu-latest
+    env:
+      # see tox.ini
+      TOXENV: docs
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install python packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Run tox (${{ env.TOXENV }})
+        run: tox
+
+      - name: Commit docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@users.noreply.github.com'
+          git add -A
+          git commit -s -m "Build docs"
+          git push

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,14 +1,12 @@
 name: docs-build
 on :
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - "mcat/*.py"
 
 jobs:
   docs-build:
-    name: Automatic docs build
+    name: Docs build
     runs-on: ubuntu-latest
     env:
       # see tox.ini
@@ -31,12 +29,20 @@ jobs:
       - name: Run tox (${{ env.TOXENV }})
         run: tox
 
-      - name: Commit docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get git status
+        id: git_status
         run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@users.noreply.github.com'
-          git add -A
-          git commit -s -m "Build docs"
-          git push
+          if [ $(git status --porcelain) == "" ]; then
+            echo ::set-output name=uncommitted::false
+          else
+            echo ::set-output name=uncommitted::true
+          fi
+
+      - name: Check for uncommited docs
+        if: ${{steps.git_status.outputs.uncommitted}}
+        run: |
+          echo "Uncommitted docs found. Faliing the job."
+          exit 1
+          
+
+          

--- a/.github/workflows/github-actions-test.yml
+++ b/.github/workflows/github-actions-test.yml
@@ -1,5 +1,11 @@
 name: test
-on : [pull_request, push]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   mcat-action-test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Auto-generated API documentation can be found in
 Run the following command to update the API documentation
 
 ```python
-PYTHONPATH=./mcat pdoc --html --output-dir docs mcat
+tox -e docs
 ```
 
 ## Blog Posts

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=./mcat/index.html" />

--- a/mcat/commentAnalysis.py
+++ b/mcat/commentAnalysis.py
@@ -14,6 +14,7 @@ class CommentAnalyzer:
         """
         Constructors form a dictionary to be used for counting.
         Parameters: words - list of words to count
+        Test docs
         """
         self.word_count = {word.lower(): 0 for word in words}  # Create dictionary with list items as key
         self.vader_sentiment = vader.SentimentIntensityAnalyzer()  # Initialize sentiment analysis model

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,20 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py
+envlist = py, docs
 skipsdist=True
 
 [testenv]
-changedir = 
-    {toxinidir}
+changedir = {toxinidir}
 deps =  
     -r{toxinidir}/requirements.txt
 
 commands =
     python -m unittest discover -s tests
+
+[testenv:docs]
+changedir = {toxinidir}
+allowlist_externals = /bin/sh
+                      /usr/bin/sh
+commands =
+    sh -c 'PYTHONPATH=./mcat pdoc --force --html --output-dir docs mcat'


### PR DESCRIPTION
Fixes #20 

Use gh actions to automatically generate the html API docs and add a new commit to the repository on each pull request.

- Add docs build environment to tox: Use tox to generate the project documentation in an isolated and reproducible environment.
- Add index.html with redirect: In order to use GitHub pages to automatically generate documentation from docs, an index file is needed in the root dir. However pdoc generates automatically the index file inside the docs/mcat dir. Add docs/index.html with a simple redirect to docs/mcat/index.html.
- Add docs build to the CI: Add a new gh actions workflow to automatically build the docs and push them to the repository on each push to main.